### PR TITLE
ET-07: Implemented self API with Authorization

### DIFF
--- a/src/main/java/com/java/eventtracker/users/contoller/UsersController.java
+++ b/src/main/java/com/java/eventtracker/users/contoller/UsersController.java
@@ -55,4 +55,16 @@ public class UsersController {
         return "User with ID " + id + " has been deleted successfully.";
     }
 
+    /**
+     * Fetch self info of the instructor
+     *
+     * @return The details of the authenticated user.
+     */
+    @GetMapping("/self")
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    public ResponseEntity<RestResponse> fetchSelfInfo() {
+        HashMap<String, Object> listHashMap = new HashMap<>();
+        listHashMap.put("users", usersService.fetchSelfInfo());
+        return RestHelper.responseSuccess(listHashMap);
+    }
 }

--- a/src/main/java/com/java/eventtracker/users/service/UsersService.java
+++ b/src/main/java/com/java/eventtracker/users/service/UsersService.java
@@ -1,5 +1,6 @@
 package com.java.eventtracker.users.service;
 
+import com.java.eventtracker.Auth.helper.UserInfoDetails;
 import com.java.eventtracker.users.mapper.UsersMapper;
 import com.java.eventtracker.utils.constants.UserConstants;
 import com.java.eventtracker.users.model.Users;
@@ -8,10 +9,13 @@ import com.java.eventtracker.users.repository.UsersRepository;
 import com.java.eventtracker.utils.exception.GlobalExceptionWrapper;
 import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.java.eventtracker.utils.constants.UserConstants.*;
 
@@ -64,6 +68,14 @@ public class UsersService implements IUsersService{
 
     @Override
     public UsersDTO fetchSelfInfo() {
-        return null;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = ((UserInfoDetails) authentication.getPrincipal()).getUsername();
+        return  findByEmail(email).orElseThrow(
+                () -> new GlobalExceptionWrapper.NotFoundException(String.format(NOT_FOUND_MESSAGE, USERS.toLowerCase())));
+    }
+
+    public Optional<UsersDTO> findByEmail(@NonNull String emailId) {
+        Optional<Users> user = this.usersRepository.findByEmail(emailId);
+        return UsersMapper.toDTO(user);
     }
 }


### PR DESCRIPTION
## Description 
Implemented self API with Authorization

## Changes Made

- [x] Added controller, repository and service for user entity
- [x] Added self API logic for user entity.

## Api created
Endpoint: http://localhost:8080/api/v1/users/self
Method: GET
Authorization: Bearer
Body: (for get requests, you don't include a body)
Response: {
    "status": true,
    "data": {
        "users": {
            "id": 52,
            "username": "dechen",
            "email": "dechen@gmail.com",
            "roles": "USER"
        }
    }
}




